### PR TITLE
ActiveStorage で画像アップロードを実装する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
@@ -65,3 +65,5 @@ gem 'carrierwave'
 gem 'devise'
 gem 'devise-i18n'
 gem 'kaminari'
+
+gem 'active_storage_validations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_storage_validations (0.9.8)
+      activejob (>= 5.2.0)
+      activemodel (>= 5.2.0)
+      activestorage (>= 5.2.0)
+      activesupport (>= 5.2.0)
     activejob (6.1.6)
       activesupport (= 6.1.6)
       globalid (>= 0.3.6)
@@ -327,6 +332,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_storage_validations
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
@@ -336,6 +342,7 @@ DEPENDENCIES
   erb_lint
   faker
   i18n_generators
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   letter_opener_web

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    keys = %i[name postal_code address self_introduction]
+    keys = %i[name postal_code address self_introduction image]
     devise_parameter_sanitizer.permit(:sign_up, keys: keys)
     devise_parameter_sanitizer.permit(:account_update, keys: keys)
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class Users::RegistrationsController < Devise::RegistrationsController
-end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,4 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  def create
-    @user.image.attach(params[:user][:image])
-  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  def create
+    @user.image.attach(params[:user][:image])
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@
 
 class UsersController < ApplicationController
   def index
-    @users = User.order(:id).page(params[:page])
+    @users = User.with_attached_image.order(:id).page(params[:page])
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_one_attached :image
-  validates :image,   content_type: { in: %w[image/jpeg image/gif image/png] },
-                      size: { less_than: 1.megabytes }
+  validates :image, content_type: { in: %w[image/jpeg image/gif image/png] }, size: { less_than: 1.megabytes }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_one_attached :image
+  validates :image,   content_type: { in: %w[image/jpeg image/gif image/png] },
+                      size: { less_than: 1.megabytes }
 end

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -19,15 +19,15 @@
 </div>
 
 <div class="image">
-    <% if user_signed_in? && current_user.image.attached? %>
-      <%= f.label :image %>
-      <%= image_tag current_user.image.variant(resize: "100x100") %>
-      <br>
-      <%= t('views.common.update_icon') %>
-      <br>
-      <%= f.file_field :image %>
-    <% else %>
-      <%= f.label :image %>
-      <%= f.file_field :image %>
-    <% end %>
+  <% if current_user&.image&.attached? %>
+    <%= f.label :image %>
+    <%= image_tag current_user.image.variant(resize: "100x100") %>
+    <br>
+    <%= t('views.common.update_icon') %>
+    <br>
+    <%= f.file_field :image %>
+  <% else %>
+    <%= f.label :image %>
+    <%= f.file_field :image %>
+  <% end %>
 </div>

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -19,8 +19,13 @@
 </div>
 
 <div class="image">
-    <% if user_signed_in? && @user.image.attached? %>
-      <%= image_tag @user.image.variant(resize: "100x100") %>
+    <% if user_signed_in? && current_user.image.attached? %>
+      <%= f.label :image %>
+      <%= image_tag current_user.image.variant(resize: "100x100") %>
+      <br>
+      <%= t('views.common.update_icon') %>
+      <br>
+      <%= f.file_field :image %><br>
     <% else %>
       <%= f.label :image %>
       <%= f.file_field :image %><br>

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -25,9 +25,9 @@
       <br>
       <%= t('views.common.update_icon') %>
       <br>
-      <%= f.file_field :image %><br>
+      <%= f.file_field :image %>
     <% else %>
       <%= f.label :image %>
-      <%= f.file_field :image %><br>
+      <%= f.file_field :image %>
     <% end %>
 </div>

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -19,7 +19,7 @@
 </div>
 
 <div class="image">
-  <% if current_user&.image&.attached? %>
+  <% if current_user && current_user.image.attached? %>
     <%= f.label :image %>
     <%= image_tag current_user.image.variant(resize: "100x100") %>
     <br>

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -17,3 +17,12 @@
   <%= f.label :self_introduction %>
   <%= f.text_area :self_introduction %>
 </div>
+
+<div class="image">
+    <% if user_signed_in? && @user.image.attached? %>
+      <%= image_tag @user.image.variant(resize: "100x100") %>
+    <% else %>
+      <%= f.label :image %>
+      <%= f.file_field :image %><br>
+    <% end %>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,6 +3,7 @@
 <table>
   <thead>
     <tr>
+      <th><%= User.human_attribute_name(:image) %></th>
       <th><%= User.human_attribute_name(:email) %></th>
       <th><%= User.human_attribute_name(:name) %></th>
       <th><%= User.human_attribute_name(:postal_code) %></th>
@@ -14,6 +15,7 @@
   <tbody>
     <% @users.each do |user| %>
       <tr>
+        <td><%= image_tag user.image.variant(resize: "30x30") if user.image.attached? %></td>
         <td><%= user.email %></td>
         <td><%= user.name %></td>
         <td><%= user.postal_code %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,7 +13,7 @@
   </thead>
 
   <tbody>
-    <% @users.all.with_attached_image.each do |user| %>
+    <% @users.each do |user| %>
       <tr>
         <td><%= image_tag user.image.variant(resize: "30x30") if user.image.attached? %></td>
         <td><%= user.email %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,7 +13,7 @@
   </thead>
 
   <tbody>
-    <% @users.each do |user| %>
+    <% @users.all.with_attached_image.each do |user| %>
       <tr>
         <td><%= image_tag user.image.variant(resize: "30x30") if user.image.attached? %></td>
         <td><%= user.email %></td>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,10 @@
 <h1><%= t('views.common.title_show', name: User.model_name.human) %></h1>
 
 <p>
+  <%= image_tag @user.image.variant(resize: "100x100") if @user.image.attached? %>
+</p>
+
+<p>
   <strong><%= User.human_attribute_name(:email) %>:</strong>
   <%= @user.email %>
 </p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -214,6 +214,7 @@ ja:
       destroy: 削除
       new: 新規作成
       back: 戻る
+      update_icon: アイコンの更新
       delete_confirm: よろしいですか？
       title_new: "%{name}の新規作成"
       title_edit: "%{name}の編集"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -133,6 +133,8 @@ ja:
       too_long: は%{count}文字以内で入力してください
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
+      content_type_invalid: はjpeg,ping,gifのみアップロード可能です
+      file_size_out_of_range: ファイルサイズは1MB以内です
     template:
       body: 次の項目を確認してください
       header:

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -15,4 +15,3 @@ ja:
         address: 住所
         self_introduction: 自己紹介文
         image: アイコン
-        

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -3,7 +3,6 @@ ja:
     models:
       book: 本  #g
       user: ユーザ
-
     attributes:
       book:
         author: 著者  #g

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -16,4 +16,4 @@ ja:
         address: 住所
         self_introduction: 自己紹介文
         image: アイコン
-        content_type: 拡張子
+        

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -15,3 +15,5 @@ ja:
         postal_code: 郵便番号
         address: 住所
         self_introduction: 自己紹介文
+        image: アイコン
+        content_type: 拡張子

--- a/db/migrate/20220905143319_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20220905143319_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_31_231050) do
+ActiveRecord::Schema.define(version: 2022_09_05_143319) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "books", force: :cascade do |t|
     t.string "title"
@@ -37,4 +65,6 @@ ActiveRecord::Schema.define(version: 2021_05_31_231050) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
## やったこと
- ユーザーが自分のアイコン画像をアップロードできるようにする
- ユーザー一覧画面とユーザー詳細画面にアイコンを表示する（未アップロードなら何も表示しない）
- 画像を表示する際、大きすぎる画像は適切なサイズにリサイズする（ファイルの容量を小さくしてネットワークの負荷を減らす）
- プロフィール編集画面にも現在設定されているアイコンを表示する
- アップロード可能なファイルはjpg, png, gifの3種類だけに限定する
- バリデーションエラーの日本語化対応
## スクリーンショット
![BooksApp 2022-09-07 22-17-52](https://user-images.githubusercontent.com/76797372/188890569-945e10ea-a10c-4608-9620-a6dec24a4cee.png)
![FireShot Capture 016 - BooksApp - localhost](https://user-images.githubusercontent.com/76797372/188890618-ac60389b-8820-41c5-a274-ed616623234a.png)
![FireShot Capture 015 - BooksApp - localhost](https://user-images.githubusercontent.com/76797372/188890665-87aef975-4a13-41be-bbca-e9d763175dd7.png)
![BooksApp 2022-09-07 22-16-21](https://user-images.githubusercontent.com/76797372/188890709-6d45f8d3-0b2e-4492-a44f-6cb26d144cdb.png)
![BooksApp 2022-09-07 22-15-33](https://user-images.githubusercontent.com/76797372/188890743-8eaa4078-df0f-4b8e-88e4-14a814c2ce07.png)
## rubocop & erb-lint
![-zsh 2022-09-07 20-57-03](https://user-images.githubusercontent.com/76797372/188890797-ce700be7-169a-4299-9fff-974d2fe3eb1e.png)
